### PR TITLE
Update copyright to correct year

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .bundle
 .idea
+.project
 config/database.yml
 db/*.sqlite3
 log/*.log

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -15,7 +15,7 @@
         <div class="span6">
             <div class="pull-right copy">
                 built by volunteers, for volunteers <br>
-                Flash Volunteer &copy; 2009-2012, a 501(c)3 nonprofit <br>
+                Flash Volunteer &copy; 2009-2014, a 501(c)3 nonprofit <br>
                 <a href="http://www.zillow.com/howto/api/neighborhood-boundaries.htm"><img src="http://www.zillowstatic.com/vstatic/ab0070e0b702ec0820aa0388637dcc68/static/logos/Zillow_Logo_HoodsProvided_RightAligned.gif" /></a>
             </div>
         </div>


### PR DESCRIPTION
1) Copyright in footer now ends in the current year.
2) I use Aptana Studio as my IDE, and it created a .project file. I want
to exclude that file from all commits, so I updated .gitignore.
