### PR TITLE
User Settings Page Layout Fix

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -33,43 +33,44 @@
                 </div>
             </div>
         </div>
+        <br>
         <div class="row-fluid">
-            <div class="span2">
+            <div class="span3">
                 <div class="pull-right"><%= f.label :name, "name"%></div>
             </div>
-            <div class="span10">
+            <div class="span8">
                 <%= f.text_field :name, :class => "full" %>
             </div>
         </div>
         <div class="row-fluid">
-            <div class="span2">
+            <div class="span3">
                 <div class="pull-right"><%= f.label :email, "email"%></div>
             </div>
-            <div class="span10">
+            <div class="span8">
                 <%= f.email_field :email, :class => "full" %>
             </div>
         </div>
         <div class="row-fluid">
-            <div class="span2">
+            <div class="span3">
                 <div class="pull-right"><%= f.label :password, "new password"%></div>
             </div>
-            <div class="span10">
+            <div class="span8">
                 <%= f.password_field :password, :class => "full" %>
             </div>
         </div>
         <div class="row-fluid">
-            <div class="span2">
+            <div class="span3">
                 <div class="pull-right"><%= f.label :password_confirmation, "confirm password"%></div>
             </div>
-            <div class="span10">
+            <div class="span8">
                 <%= f.password_field :password_confirmation, :class => "full" %>
             </div>
         </div>
         <div class="row-fluid">
-            <div class="span2">
+            <div class="span3">
                 <div class="pull-right"><%= f.label :birthday, "birthday", :class=>"full" %></div>
             </div>
-            <div class="span4">
+            <div class="span2">
                 <input id="user_birthday" class="full" name="user[birthday]" value="<%= @user.birthday.strftime('%-m/%-d/%Y') unless !@user.birthday %>" />
 
                 <script type="text/javascript">
@@ -84,22 +85,22 @@
             </div>
         </div>
         <div class="row-fluid">
-            <div class="span2">
+            <div class="span3">
                 <div class="pull-right"><%= f.label :description, "about me"%></div>
             </div>
-            <div class="span10">
+            <div class="span8">
                 <%= f.text_field :description, :class => "full" %>
             </div>
         </div>
         <div class="row-fluid">
-            <div class="span2">
+            <div class="span3">
                 <div class="pull-right"><%= f.label :categories, "categories", :for=>"email" %></div>
             </div>
-            <div class="span10">
+            <div class="span8">
                 <%= render(:partial => 'skills/form', :locals => { :entity => "user", :f => f, :skills => @user.skills }) %>
             </div>
         </div>
-        <div class="row-fluid">
+        <div class="row-fluid span11">
             <button type="submit" href="#" class="btn btn-primary pull-right">update</button>   
         </div>
     <% end %>


### PR DESCRIPTION
Currently, the users settings page looks like this:
![screen shot 2015-03-19 at 1 23 11 pm](https://cloud.githubusercontent.com/assets/8314655/6742328/1e58b7da-ce4c-11e4-9195-cec564b1bef5.png)

The confirm password label is two lines, which looks a little tacky. Also, the overall title bar's width is smaller than the width of the fields below. With this PR, the page will look like this:
![screen shot 2015-03-19 at 3 22 51 pm](https://cloud.githubusercontent.com/assets/8314655/6742342/4a447136-ce4c-11e4-9d06-a18109dd5eed.png)

This wasn't in any of the current issues on Assembla but it's been bugging me since I noticed this. Not a top priority issue, but figured that it'll need to be fixed sometime.