### PR TITLE
Create Event Form Character Color Change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 ruby '1.9.3'
 source 'http://rubygems.org'
 
-gem 'rails', '3.2.18' 
+gem 'rails', '3.2.18'
 gem 'json', '~> 1.7.7'
 
 # Pagination
@@ -63,6 +63,8 @@ gem 'rgeo'
 gem 'rgeo-geojson'
 gem 'activerecord-mysql2spatial-adapter'
 
+gem 'newrelic_rpm'
+
 group :development do
   gem 'factory_girl_rails'
   gem 'rails-footnotes'
@@ -71,12 +73,11 @@ group :development do
 end
 
 group :production do
-    gem 'newrelic_rpm'
     # http://www.imagemagick.com/www/binary-releases.html#windows
     # https://github.com/rmagick/rmagick/wiki/Installing-on-Windows
     # LKG is 6.7.9.9 - http://ftp.sunet.se/pub/multimedia/graphics/ImageMagick/binaries/
     # http://ftp.sunet.se/pub/multimedia/graphics/ImageMagick/binaries/ImageMagick-6.7.7-0-Q16-windows-dll.exe
     # http://stackoverflow.com/questions/4451213/ruby-1-9-2-how-to-install-rmagick-on-windows
-    gem "rmagick" 
+    gem "rmagick"
     gem "unicorn"
 end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -302,17 +302,21 @@
           $('#si_chars_left').text(2000 - cs);
           if(cs > 2000) {
             $(this).css("border", "1px solid red");
-          } else {
-            $(this).css("border", "");
+			document.getElementById("si_chars_left").style.color = 'red';
+		  } else {
+		  	$(this).css("border", "");
+		  	document.getElementById("si_chars_left").style.color = 'black';
           }
       });
       $("#event_description").on('change keyup paste', function() {
           var cs = $(this).val().length;
           $('#description_chars_left').text(2000 - cs);
           if(cs > 2000) {
-            $(this).css("border", "1px solid red");
+				  $(this).css("border", "1px solid red");
+				  document.getElementById("description_chars_left").style.color = 'red';
           } else {
-            $(this).css("border", "");
+		  	$(this).css("border", "");
+			document.getElementById("description_chars_left").style.color = 'black';
           }
       });
       $("#event_special_instructions").change();


### PR DESCRIPTION
In the "Create Event" form, I fixed the problem where the character count didn't turn red when the number of characters was greater than 2000. This applies to the description box and the special instructions box.