### PR TITLE
Changing password message for organizations and also allowing organizati...

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -77,6 +77,21 @@
       <% if flash[:password] %>
         <% if current_user != nil %>
           <div class="alert alert-error">
+            <% if current_user.type == "Org" %>
+              <h4 class="alert-heading">Your organization has no password!</h4>
+              <p>
+                  <ul>
+                      <li>It appears that you have no password for your organization.
+                        If you don't create one, you will not be able to sign into your
+                        organization with it's email. Click 
+                        <% if current_user.type == "Org" %>
+                            <%= link_to "here", edit_org_url(current_user) %>
+                        <% else %>
+                            <%= link_to "here", edit_user_url(current_user) %>
+                        <% end %> to set your password!</li>
+                  </ul>
+              </p>
+            <% else %>
               <h4 class="alert-heading">You need to set your account password!</h4>
               <p>
                   <ul>
@@ -90,6 +105,7 @@
                         <% end %> to set your password!</li>
                   </ul>
               </p>
+            <% end %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/orgs/_form.html.erb
+++ b/app/views/orgs/_form.html.erb
@@ -46,6 +46,22 @@
       </div>
   </div>
   <div class="row-fluid">
+    <div class="span2">
+        <div class="pull-right"><%= f.label :password, "password" %></div>
+    </div>
+    <div class="span9">
+      <%= f.password_field :password, :class=>"full" %>
+    </div>
+  </div>
+  <div class="row-fluid">
+    <div class="span2">
+        <div class="pull-right"><%= f.label :password_confirmation, "confirm password" %></div>
+    </div>
+    <div class="span9">
+      <%= f.password_field :password_confirmation, :class=>"full" %>
+    </div>
+  </div>
+  <div class="row-fluid">
       <div class="span2">
           <div class="pull-right"><%= f.label :mission, "mission"%></div>
       </div>


### PR DESCRIPTION
Makes setting a password a possibility for existing organizations (and a requirement for new organizations), which should be a feature in my opinion so then organizations can login through the main login system with the organizations email and password. Will display the following message if a password is not set for an organization.
![screen shot 2015-04-03 at 3 39 45 pm](https://cloud.githubusercontent.com/assets/8314655/6989987/df367e02-da17-11e4-960c-44449751e7fc.png)